### PR TITLE
Fixed bugs in ASM, WavelengthContainer and Coherent Source

### DIFF
--- a/holotorch/LightSources/CoherentSource.py
+++ b/holotorch/LightSources/CoherentSource.py
@@ -53,20 +53,22 @@ class CoherentSource(Source):
         height : int,
         width  : int,
         spacing : float = 8 * um,
-        wavelengths : tuple = [432 * nm, 530 * nm, 630 * nm],
+        wavelengths : list = [432 * nm, 530 * nm, 630 * nm],
     ) -> CoherentSource:
 
+        if type(wavelengths) is not list:
+            wavelengths = [wavelengths]
         # Define the wavelengths
         wavelength_container = WavelengthContainer(
-            wavelengths = [432 * nm, 530 * nm, 630 * nm],
-            tensor_dimension = Dimensions.C(n_channel=3)
+            wavelengths = wavelengths,
+            tensor_dimension = Dimensions.C(n_channel=len(wavelengths))
             # We need to tell the container at which dimension the data should work on
             # This resolves confusion for more complicates tasks (such as partial coherence)
             )
 
         # Define the spacing
         spacing_container = SpacingContainer(
-            spacing = 8 * um
+            spacing = spacing
             )
 
         # The spacing will automatically extend to other dimensions (by default Time,Channel and xy)
@@ -75,8 +77,8 @@ class CoherentSource(Source):
         # Defines the pixel resolution of the source
         source_dim      = Dimensions.CHW(
                 n_channel    = wavelength_container.channel,
-                height       = 1000,
-                width        = 1400,
+                height       = height,
+                width        = width,
             )
 
         source = CoherentSource(

--- a/holotorch/Optical_Propagators/ASM_Prop.py
+++ b/holotorch/Optical_Propagators/ASM_Prop.py
@@ -209,7 +209,8 @@ class ASM_Prop(CGH_Component):
 
         if self.prop_kernel_type is ENUM_PROP_KERNEL_TYPE.PARAXIAL_KERNEL:
             # avoid sqrt operation
-            ang = self.z * K_lambda[:,:,None,None] + self.z/(2*K_lambda)*K2 # T x C x H x W
+            #ang = self.z * K_lambda[:,:,None,None] + self.z/(2*K_lambda)*K2 # T x C x H x W
+            ang = self.z * K_lambda + self.z/(2*K_lambda)*K2 # T x C x H x W
         elif self.prop_kernel_type is ENUM_PROP_KERNEL_TYPE.FULL_KERNEL:
             ang = - self.z * torch.sqrt(K_lambda_2 - K2) # T x C x H x W
             if ang.is_complex():

--- a/holotorch/Spectra/WavelengthContainer.py
+++ b/holotorch/Spectra/WavelengthContainer.py
@@ -15,7 +15,7 @@ import torch
 import torch.nn as nn
 
 from holotorch.utils.Dimensions import *
-
+from holotorch.utils.units import *
 class WavelengthContainer(nn.Module):
     
     def __init__(self,


### PR DESCRIPTION
Hi there, I recently used the Holotorch library in a personal project and came across some bugs in three of the files. Here's a list of the bugs and how I fixed them:

In the 'CoherentSource.py' file under 'LightSources', the module was manually set instead of using the parameters for height, width, spacing, and wavelengths. To fix this, I simply replaced the argument names with the corresponding variable setting.

In the 'ASM_Prop.py' file under 'Optical_Propagators', a bug was found in the tensor shapes when 'prop_kernel_type' is 'ENUM_PROP_KERNEL_TYPE.PARAXIAL_KERNEL' in line 212. I fixed this by removing the new dimensions from 'K_lambda' and setting it as it is.

In the 'WavelengthContainer.py' file under 'Spectra', the 'nm' units were not imported, making it impossible to work directly in the file. To fix this, I imported the 'units' module.

Best Regards.